### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ module wa-lang.org/wa
 go 1.17
 
 require (
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 	wa-lang.org/wabt-go v1.2.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 wa-lang.org/wabt-go v1.2.3 h1:xwGW3+IrCMAPDx+ngQFx7vl0xBc1vuooRNql7i2yCiA=
 wa-lang.org/wabt-go v1.2.3/go.mod h1:v4fKY/p4oMiKwQ2S2aC/wOXvJ2bk2MgtLmwK0TKTNx0=

--- a/internal/app/waruntime/arduino.go
+++ b/internal/app/waruntime/arduino.go
@@ -63,10 +63,10 @@ func ArduinoInstantiate(ctx context.Context, rt wazero.Runtime) (api.Closer, err
 		Export("getPinLED").
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, m api.Module, ptr, len uint32) {
-			bytes, _ := m.Memory().Read(ctx, ptr, len)
+			bytes, _ := m.Memory().Read(ptr, len)
 			fmt.Printf("arduino.print(%q)\n", string(bytes))
 		}).
 		WithParameterNames("ptr", "len").
 		Export("print").
-		Instantiate(ctx, rt)
+		Instantiate(ctx)
 }

--- a/internal/app/waruntime/chrome.go
+++ b/internal/app/waruntime/chrome.go
@@ -11,5 +11,5 @@ import (
 )
 
 func ChromeInstantiate(ctx context.Context, rt wazero.Runtime) (api.Closer, error) {
-	return rt.NewHostModuleBuilder(config.WaOS_Chrome).Instantiate(ctx, rt)
+	return rt.NewHostModuleBuilder(config.WaOS_Chrome).Instantiate(ctx)
 }

--- a/internal/app/waruntime/walang.go
+++ b/internal/app/waruntime/walang.go
@@ -16,7 +16,7 @@ func WalangInstantiate(ctx context.Context, rt wazero.Runtime) (api.Closer, erro
 	return rt.NewHostModuleBuilder(envWalang).
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, m api.Module, pos, len uint32) {
-			bytes, _ := m.Memory().Read(ctx, pos, len)
+			bytes, _ := m.Memory().Read(pos, len)
 			fmt.Print(string(bytes))
 		}).
 		WithParameterNames("pos", "len").
@@ -33,5 +33,5 @@ func WalangInstantiate(ctx context.Context, rt wazero.Runtime) (api.Closer, erro
 		}).
 		WithParameterNames("ch").
 		Export("waPrintRune").
-		Instantiate(ctx, rt)
+		Instantiate(ctx)
 }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) which notably has signature changes due to removal of the Namespace type.