### PR TITLE
CmdRunAction: avoid duplication err message output

### DIFF
--- a/internal/app/apprun/apprun.go
+++ b/internal/app/apprun/apprun.go
@@ -174,13 +174,15 @@ func CmdRunAction(c *cli.Context) error {
 			os.Exit(exitCode)
 		}
 		fmt.Println(err)
+	} else {
+		if len(stdout) > 0 {
+			fmt.Fprint(os.Stdout, string(stdout))
+		}
+		if len(stderr) > 0 {
+			fmt.Fprint(os.Stderr, string(stderr))
+		}
 	}
-	if len(stdout) > 0 {
-		fmt.Fprint(os.Stdout, string(stdout))
-	}
-	if len(stderr) > 0 {
-		fmt.Fprint(os.Stderr, string(stderr))
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
When err is not nil, but it is not as ```*sys.ExitError``` , the stdout and stderr is duplication output.