### PR TITLE
Fixed issue #67.

### DIFF
--- a/internal/backends/compiler_wat/wir/util.go
+++ b/internal/backends/compiler_wat/wir/util.go
@@ -177,7 +177,11 @@ func GetFnMangleName(v interface{}, mainPkg string) (internal string, external s
 	exported := true
 	switch f := v.(type) {
 	case *ssa.Function:
-		if recv := f.Signature.Recv(); recv != nil {
+		recv := f.Signature.Recv()
+		if recv == nil && f.Anonymous() && f.Parent().Signature != nil {
+			recv = f.Parent().Signature.Recv()
+		}
+		if recv != nil {
 			//if recv.Pkg().Path() != mainPkg {
 			//	exported = false
 			//} else {

--- a/internal/ssa/builder.go
+++ b/internal/ssa/builder.go
@@ -522,6 +522,7 @@ func (b *builder) expr0(fn *Function, e ast.Expr, tv types.TypeAndValue) Value {
 			Pkg:       fn.Pkg,
 			Prog:      fn.Prog,
 			syntax:    e,
+			anonymous: true,
 		}
 		fn.AnonFuncs = append(fn.AnonFuncs, fn2)
 		b.buildFunction(fn2)

--- a/internal/ssa/ssa.go
+++ b/internal/ssa/ssa.go
@@ -322,6 +322,7 @@ type Function struct {
 	namedResults []*Alloc                // tuple of named results
 	targets      *targets                // linked stack of branch targets
 	lblocks      map[*ast.Object]*lblock // labelled blocks
+	anonymous    bool                    // true if this function is anonymous
 }
 
 // BasicBlock represents an SSA basic block.
@@ -1373,6 +1374,7 @@ func (v *Global) ForceRegister() bool {
 	return info.ForceRegister
 }
 
+func (v *Function) Anonymous() bool { return v.anonymous }
 func (v *Function) Name() string         { return v.name }
 func (v *Function) Type() types.Type     { return v.Signature }
 func (v *Function) Pos() token.Pos       { return v.pos }

--- a/wca/check-cla.go
+++ b/wca/check-cla.go
@@ -26,6 +26,7 @@ var wcaMap = map[string]bool{
 	"visus@qq.com":                true,
 	"wuxuan.ecios@gmail.com":      true,
 	"zhanluxianshen@163.com":      true,
+	"dragon-fly@qq.com":           true,
 }
 
 func main() {


### PR DESCRIPTION
This PR resolves a naming conflict issue for anonymous functions within struct methods by incorporating the struct name into their link names. This change ensures unique naming for closures and improving support for struct methods with closures.