### PR TITLE
Fixed issue #72.

### DIFF
--- a/internal/types/builtins.go
+++ b/internal/types/builtins.go
@@ -562,6 +562,27 @@ func (check *Checker) builtin(x *operand, call *ast.CallExpr, id builtinId) (_ b
 					// TODO(gri) "use" all arguments?
 					return
 				}
+				switch i {
+				case 0:
+					if !isPointer(x.typ) {
+						check.invalidArg(x.pos(), "%s is not a pointer", x)
+						return
+					}
+				case 1:
+					sig, ok := x.typ.(*Signature)
+					if !ok {
+						check.invalidArg(x.pos(), "%s is not a function", x)
+						return
+					}
+					if sig.Params().Len() != 1 || sig.Results().Len() != 0 {
+						check.invalidArg(x.pos(), "expect 1 parameter and 0 result for function, but found %d and %d", sig.Params().Len(), sig.Results().Len())
+						return
+					}
+					if sig.Params().At(0).Type().String() != "u32" {
+						check.invalidArg(x.pos(), "expect u32 as parameter for function, but found %s", sig.Params().At(0).Type().String())
+						return
+					}
+				}
 				params[i] = x.typ
 			}
 		}

--- a/internal/types/testdata/builtins.src
+++ b/internal/types/testdata/builtins.src
@@ -900,3 +900,10 @@ func trace2() {
 	// trace(f2(), 1, 2, 3)
 	// trace(f3(), 1, 2, 3, 4)
 }
+
+func setFinalizer1() {
+	i := 1
+	setFinalizer(i, func(ptr: i32) {}) // ERROR is not a pointer
+	setFinalizer(&i, func(ptr: i32) {}) // ERROR expect u32 as parameter
+	setFinalizer(&i, func(ptr: u32, y: i64) {}) // ERROR expect 1 parameter and 0 result
+}


### PR DESCRIPTION
Created a PR to test the `setFinalizer` built-in function with the signature `func setFinalizer(ptr: Pointer, finalizer: func(addr: u32))`. This includes test data for validating error messages.